### PR TITLE
refactor: 버튼 및 인풋 컴포넌트 타입 개선 및 Storybook 수정

### DIFF
--- a/src/shared/ui/components/DefaultButton.tsx
+++ b/src/shared/ui/components/DefaultButton.tsx
@@ -2,13 +2,18 @@ import { flexStyles } from '@/shared';
 import * as stylex from '@stylexjs/stylex';
 import { memo } from 'react';
 
+type NativeButtonProps = React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
 type ButtonProps = {
   command: string;
-  onClick?: React.MouseEventHandler<HTMLElement>;
-  type?: 'submit' | 'button' | 'reset';
+  onClick?: NativeButtonProps['onClick'];
+  type?: NativeButtonProps['type'];
+  disabled?: NativeButtonProps['disabled'];
   variant?: 'primary' | 'kakao' | 'cancel' | 'close';
-  disabled?: boolean;
-  icon?: React.ReactNode;
+  icon?: JSX.Element;
 };
 
 const DefaultButton = ({

--- a/src/shared/ui/components/InputWithLabel.tsx
+++ b/src/shared/ui/components/InputWithLabel.tsx
@@ -3,11 +3,16 @@ import * as stylex from '@stylexjs/stylex';
 import { memo } from 'react';
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
+type NativeInputProps = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>;
+
 type InputWithLabelProps = {
   label: string;
   register: UseFormRegisterReturn;
-  placeholder?: string;
-  type: string;
+  placeholder?: NativeInputProps['placeholder'];
+  type: NativeInputProps['type'];
 };
 
 const InputWithLabel = ({ label, register, ...props }: InputWithLabelProps) => {

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -3,13 +3,13 @@ import { fn } from '@storybook/test';
 import { DefaultButton } from '@/shared';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
-const meta: Meta = {
+const meta = {
   title: 'Components/Button',
   component: DefaultButton,
   parameters: {},
   tags: ['autodocs'],
-  args: { onClick: fn() },
-} satisfies Meta;
+  args: { onClick: () => alert('Button clicked') },
+} satisfies Meta<typeof DefaultButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
-import { DefaultButton } from '@/shared';
+import { DefaultButton, KakaoIcon } from '@/shared';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -31,6 +30,7 @@ export const Kakao: Story = {
     variant: 'kakao',
     disabled: false,
     type: 'button',
+    icon: <KakaoIcon />,
   },
 };
 


### PR DESCRIPTION
### 상세

-  NativeButtonProps, NativeInputProps를 활용하여 기존 개별 속성 타입 정의를 제거하고 HTML 기본 속성을 상속하도록 변경, Storybook의 meta 타입 개선
- Storybook 스토리 파일의 확장자를 .stories.ts → .stories.tsx로 변경, 카카오 로그인 버튼에 아이콘 추가
- onClick 이벤트에 alert 추가하여 동작 확인
