### PR TITLE
fix(chat): 메시지 전송 후 UI가 갱신되지 않던 문제 해결

### DIFF
--- a/src/features/chat/apis.ts
+++ b/src/features/chat/apis.ts
@@ -1,5 +1,5 @@
 import { handleError, NonNullable, supabase } from '@/shared';
-import type { Messages, RawChat, RawFriend } from './types';
+import type { RawChat, RawFriend, Message } from './types';
 
 export const fetchUserChats = async (userId: NonNullable<string>) =>
   (await supabase
@@ -15,7 +15,7 @@ export const fetchUserFriends = async (userId: NonNullable<string>) =>
     .eq('user_id', userId)
     .then(handleError)) as RawFriend[];
 
-export const sendChatMessage = async ({ chat_id, user_id, body }: Messages) =>
+export const sendChatMessage = async ({ chat_id, user_id, body }: Message) =>
   await supabase
     .from('messages')
     .insert([{ chat_id, user_id, body }])

--- a/src/features/chat/hooks/useRealTimeMessages.tsx
+++ b/src/features/chat/hooks/useRealTimeMessages.tsx
@@ -1,13 +1,13 @@
 import { NonNullable, supabase } from '@/shared';
 import { useEffect, useCallback } from 'react';
-import type { Messages } from '@/features/chat';
+import type { Message } from '@/features/chat';
 
 const useRealTimeMessages = (
   chatId: NonNullable<string>,
-  onNewMessage: (message: Messages) => void,
+  onNewMessage: (message: Message) => void,
 ) => {
   const handleNewMessage = useCallback(
-    (payload: { new: Messages }) => {
+    (payload: { new: Message }) => {
       onNewMessage(payload.new);
     },
     [onNewMessage],

--- a/src/features/chat/model/useMessageQuery.tsx
+++ b/src/features/chat/model/useMessageQuery.tsx
@@ -1,6 +1,6 @@
 import { handleError, supabase } from '@/shared';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { Messages } from '../types';
+import { Message } from '../types';
 
 const PAGE_SIZE = 20;
 
@@ -20,7 +20,7 @@ const useMessagesQuery = (chatId: string | undefined) => {
     },
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-    select: (data) => data.pages.flat().reverse() as Messages[],
+    select: (data) => data.pages.flat().reverse() as Message[],
     enabled: !!chatId,
     initialPageParam: 0,
     staleTime: 1000 * 60,

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -22,11 +22,11 @@ type MapRawChatToChatItem<T extends RawChat> = {
 
 export type ChatItem = MapRawChatToChatItem<RawChat>;
 
-export type Messages = {
+export type Message = {
   chat_id: string;
   user_id: string;
-  id?: number;
   body: string;
+  id?: number | string;
   created_at?: string;
 };
 

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -2,7 +2,6 @@ import { userIdAtom } from '@/entities/auth';
 import {
   useChatInfoMutation,
   useIntersectionObserver,
-  useMessageMutation,
   useMessages,
 } from '@/features/chat';
 import { flexStyles } from '@/shared';
@@ -36,9 +35,13 @@ const ChatRoom = () => {
   const [autoScroll, setAutoScroll] = useState(true);
   const [scrollPosition, setScrollPosition] = useState<number | null>(null);
 
-  const { messages, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useMessages(chatId);
-  const { mutate: mutateMessage } = useMessageMutation(chatId);
+  const {
+    messages,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    handleSendMessage,
+  } = useMessages(chatId);
   const { mutate: mutateIsNew } = useChatInfoMutation();
 
   const observe = useIntersectionObserver(
@@ -80,14 +83,14 @@ const ChatRoom = () => {
     async (data: SendMessage) => {
       if (!userId || !data.newMessage.trim()) return;
 
-      mutateMessage({
+      await handleSendMessage({
         chat_id: chatId!,
         user_id: userId,
         body: data.newMessage,
       });
       reset();
     },
-    [chatId, userId, mutateMessage, reset],
+    [chatId, userId, reset],
   );
 
   useEffect(() => {


### PR DESCRIPTION
### 변경사항
- message mutation 로직을 useMessages 훅 안으로 이전하여, 메시지 전송 시 Optimistic UI 업데이트 적용
- 타입 이름(Messages)을 message로 수정하여 네이밍 일관성 개선